### PR TITLE
BASIC認証導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
+
+  private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == 'hirowood' && password == '0727'
+    end
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,14 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 0) do
+end


### PR DESCRIPTION
#What
Basic認証導入

#Why
##開発環境やステージング環境の保護

 -開発中のアプリケーションを一般公開せずに特定の関係者のみが閲覧できるようにする。

 -時的な閲覧制限を低コストで実施できる。

##迅速な導入が可能

 -他の認証手段（OAuth、JWT、セッション認証）よりもシンプルで素早く導入できる。

 -サーバーサイドの設定のみで実現可能であるため、工数が少なくて済む。

##簡易的なアクセス制限

 -時的にサイト全体を保護する用途に向いている（例：メンテナンス時のアクセス制限）。

